### PR TITLE
Add ForReadingWithMaxLength() to allow controlling maximum message length

### DIFF
--- a/netstring_test.go
+++ b/netstring_test.go
@@ -50,6 +50,15 @@ func TestReading(t *testing.T) {
 	}
 }
 
+func TestReadingMaxLength(t *testing.T) {
+	n := ForReadingWithMaxLength(10)
+	input := bytes.NewBufferString("11:hello world,")
+	err := n.ReadFrom(input)
+	if err != TooLarge {
+		t.Fatal(err)
+	}
+}
+
 func TestIncomplete(t *testing.T) {
 	n := ForReading()
 	input := bytes.NewBufferString("1")


### PR DESCRIPTION
Thus controlling how much memory is used during parsing and to prevent an attacker to cause a process to run out of memory on parsing netstrings by providing a large length which could cause a large buffer to be allocated.

I've preferred adding a new  builder in order not to break the package API.

I've found this issue during fuzzing a library that depends on this package.